### PR TITLE
Make headers optional in GpsSender.

### DIFF
--- a/Transport/GpsSender.php
+++ b/Transport/GpsSender.php
@@ -41,7 +41,7 @@ final class GpsSender implements SenderInterface
         $messageBuilder = new MessageBuilder();
         $messageBuilder = $messageBuilder->setData($encodedMessage['body']);
 
-        if (array_key_exists('headers', $encodedMessage)) {
+        if (\array_key_exists('headers', $encodedMessage)) {
             $messageBuilder->addAttribute('headers', json_encode($encodedMessage['headers']));
         }
 

--- a/Transport/GpsSender.php
+++ b/Transport/GpsSender.php
@@ -42,7 +42,7 @@ final class GpsSender implements SenderInterface
         $messageBuilder = $messageBuilder->setData($encodedMessage['body']);
 
         if (\array_key_exists('headers', $encodedMessage)) {
-            $messageBuilder->addAttribute('headers', json_encode($encodedMessage['headers']));
+            $messageBuilder = $messageBuilder->addAttribute('headers', json_encode($encodedMessage['headers']));
         }
 
         $redeliveryStamp = $envelope->last(RedeliveryStamp::class);

--- a/Transport/GpsSender.php
+++ b/Transport/GpsSender.php
@@ -39,8 +39,11 @@ final class GpsSender implements SenderInterface
         $encodedMessage = $this->serializer->encode($envelope);
 
         $messageBuilder = new MessageBuilder();
-        $messageBuilder = $messageBuilder->setData($encodedMessage['body'])
-            ->addAttribute('headers', json_encode($encodedMessage['headers']));
+        $messageBuilder = $messageBuilder->setData($encodedMessage['body']);
+
+        if (array_key_exists('headers', $encodedMessage)) {
+            $messageBuilder->addAttribute('headers', json_encode($encodedMessage['headers']));
+        }
 
         $redeliveryStamp = $envelope->last(RedeliveryStamp::class);
         if ($redeliveryStamp instanceof RedeliveryStamp) {


### PR DESCRIPTION
Headers are not populated when PhpSerializer is used.