### PR TITLE
Create topic in sender constructor. Add batch publishing.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,7 +34,7 @@ jobs:
         run: vendor/bin/php-cs-fixer fix --dry-run
         
       - name: Run static analyse tests
-        run: vendor/bin/phpstan analyse Tests Transport --level=5
+        run: vendor/bin/phpstan analyse
         
       - name: Run unit tests
         run: vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ framework:
                         name: 'messages'
                     queue: # optional (default the same as topic.name)
                         name: 'messages'
+                    batch_size: 0 # optional (default: 0) If set above 0 it uses pubsubs batch publisher 
 ```
 or:
 ```yaml

--- a/Transport/GpsConfiguration.php
+++ b/Transport/GpsConfiguration.php
@@ -14,11 +14,13 @@ final class GpsConfiguration implements GpsConfigurationInterface
     private $maxMessagesPull;
     private $keyFilePath;
     private $messageType;
+    private $batchSize;
 
     public function __construct(
         string $queueName,
         string $subscriptionName,
         int $maxMessagesPull,
+        int $batchSize,
         ?string $keyFilePath = null,
         ?string $messageType = null
     ) {
@@ -27,6 +29,7 @@ final class GpsConfiguration implements GpsConfigurationInterface
         $this->maxMessagesPull = $maxMessagesPull;
         $this->keyFilePath = $keyFilePath;
         $this->messageType = $messageType;
+        $this->batchSize = $batchSize;
     }
 
     public function getQueueName(): string
@@ -52,5 +55,10 @@ final class GpsConfiguration implements GpsConfigurationInterface
     public function getMessageType(): ?string
     {
         return $this->messageType;
+    }
+
+    public function getBatchSize(): int
+    {
+        return $this->batchSize;
     }
 }

--- a/Transport/GpsConfigurationInterface.php
+++ b/Transport/GpsConfigurationInterface.php
@@ -18,4 +18,6 @@ interface GpsConfigurationInterface
     public function getKeyFilePath(): ?string;
 
     public function getMessageType(): ?string;
+
+    public function getBatchSize(): int;
 }

--- a/Transport/GpsConfigurationResolver.php
+++ b/Transport/GpsConfigurationResolver.php
@@ -24,6 +24,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
         $optionsResolver
             ->setDefault('max_messages_pull', self::DEFAULT_MAX_MESSAGES_PULL)
             ->setDefault('key_file_path', null)
+            ->setDefault('batch_size', 0)
             ->setDefault('message_type', null)
             ->setDefault('topic', static function (OptionsResolver $topicResolver): void {
                 $topicResolver
@@ -42,6 +43,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             })
             ->setAllowedTypes('max_messages_pull', ['int', 'string'])
             ->setAllowedTypes('key_file_path', ['string', 'null'])
+            ->setAllowedTypes('batch_size', ['int'])
             ->setAllowedTypes('message_type', ['string', 'null'])
         ;
 
@@ -64,6 +66,7 @@ final class GpsConfigurationResolver implements GpsConfigurationResolverInterfac
             $resolvedOptions['topic']['name'],
             $resolvedOptions['queue']['name'],
             $resolvedOptions['max_messages_pull'],
+            $resolvedOptions['batch_size'],
             $resolvedOptions['key_file_path'],
             $resolvedOptions['message_type']
         );

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "phpunit/phpunit": "^8",
         "phpspec/prophecy-phpunit": "^1.1",
         "friendsofphp/php-cs-fixer": "^2.17",
-        "phpstan/phpstan": "^0.12.64"
+        "phpstan/phpstan": "^0.12.64",
+        "jangregor/phpstan-prophecy": "^0.8.1"
     },
     "autoload": {
         "psr-4": { "PetitPress\\GpsMessengerBundle\\": "" }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,2 +1,8 @@
 parameters:
-	ignoreErrors:
+    level: 5
+    paths:
+        - Tests
+        - Transport
+    ignoreErrors:
+includes:
+    - vendor/jangregor/phpstan-prophecy/extension.neon


### PR DESCRIPTION
This improves publishing in long-running processes. Topic will now be checked if it exits only once per process.
Adding option for batch publishing improves publishing performance in higher throughput scenarios